### PR TITLE
openshift-tasks

### DIFF
--- a/openshift-tasks/src/openshift.00.intro.md
+++ b/openshift-tasks/src/openshift.00.intro.md
@@ -16,3 +16,4 @@ aforementioned learning portal to familiarise yourself with the learning
 environment:
     * [Foundations of OpenShift/Logging in to an OpenShift Cluster](https://learn.openshift.com/introduction/cluster-access/)
 * (_Optional_) Install and run CRC instance on your machine (might require 16GB RAM)
+    * [Red Hat OpenShift 4 on your laptop: Introducing Red Hat CodeReady Containers](https://developers.redhat.com/blog/2019/09/05/red-hat-openshift-4-on-your-laptop-introducing-red-hat-codeready-containers/)

--- a/openshift-tasks/src/openshift.1.1.cli.md
+++ b/openshift-tasks/src/openshift.1.1.cli.md
@@ -8,6 +8,7 @@
 ## Reference Info
 
 * [OpenShift CLI (OC)](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/cli_tools/openshift-cli-oc)
+* [Enable autocompletion](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/configuring-cli.html)
 * [Developer CLI commands](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/developer-cli-commands.html)
 * [Administrator CLI commands](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/administrator-cli-commands.html)
 * [Usage of oc and kubectl commands](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/usage-oc-kubectl.html)

--- a/openshift-tasks/src/openshift.1.1.cli.md
+++ b/openshift-tasks/src/openshift.1.1.cli.md
@@ -7,8 +7,6 @@
 
 ## Reference Info
 
-* [Getting started with the CLI](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html)
-* [Enable autocompletion](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/configuring-cli.html)
 * [OpenShift CLI (OC)](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/cli_tools/openshift-cli-oc)
 * [Developer CLI commands](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/developer-cli-commands.html)
 * [Administrator CLI commands](https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/administrator-cli-commands.html)

--- a/openshift-tasks/src/openshift.1.1.cli.md
+++ b/openshift-tasks/src/openshift.1.1.cli.md
@@ -18,7 +18,7 @@
 * Install `oc` client
 * Show `oc` version
 * (Optional) Setup autocompletion
-* Start OpenShift Playground and use Web Console to find out login command
+* Start [OpenShift Playground](https://learn.openshift.com/playgrounds/) and use Web Console to find out login command
 * Connect to Playground instance via local `oc`
 * Identify contexts and the current context
 * Get status of OpenShift instance

--- a/openshift-tasks/src/openshift.1.2.web-console.md
+++ b/openshift-tasks/src/openshift.1.2.web-console.md
@@ -14,7 +14,7 @@
 
 > All tasks should be performed via Web Console unless explicitly stated otherwise
 
-* Log into Web Console under Developer & Administrator accounts. Mind the difference in access.
+* Log into [Web Console](https://learn.openshift.com/playgrounds/openshift42/) under Developer & Administrator accounts. Mind the difference in access.
 * Switch between Developer & Administrator perspectives. What perspective should one
     one use to reach the following and what is the path through menus (e.g. 
     _Home/Dashboards_):

--- a/openshift-tasks/src/openshift.1.3.projects.md
+++ b/openshift-tasks/src/openshift.1.3.projects.md
@@ -11,7 +11,7 @@
 
 ## Tasks
 
-* Create project from GUI (Developer perspective)
+* Create project from [GUI](https://learn.openshift.com/playgrounds/openshift42/) (Developer perspective)
 * Create another project from GUI (Admin perspective)
 * Create yet another project from CLI
 * Check what is the the current project set in CLI

--- a/openshift-tasks/src/openshift.1.5.status.md
+++ b/openshift-tasks/src/openshift.1.5.status.md
@@ -8,11 +8,13 @@
 ## Reference Info
 
 * [Monitoring application health](https://docs.openshift.com/container-platform/4.2/applications/application-health.html)
+* [Viewing and listing the nodes in your OpenShift Container Platform cluster](https://docs.openshift.com/container-platform/4.2/nodes/nodes/nodes-nodes-viewing.html)
+* [Viewing system event information in an OpenShift Container Platform cluster](https://docs.openshift.com/container-platform/4.2/nodes/clusters/nodes-containers-events.html)
 
 ## Tasks
 
 * Follow instructions in playground to create new project then switch to it and deploy
-    applications.
+    applications (deploying application from [images](https://learn.openshift.com/introduction/deploying-images/) or [source](https://learn.openshift.com/introduction/deploying-python/)).
 * Get status of the apps in the project
 * Get status together with suggestions regarding how to improve the state of the project.
     What does the tool suggest? 


### PR DESCRIPTION
1. openshift.00.intro.md
    - added link to CRC installation description

2. openshift.1.1.cli.md
    - deleted _Getting started with the CLI_ as OpenShift CLI (OC) has the same content 
    - added OpenShift Playground link for quick access

3. openshift.1.2.web-console.md
    - added OpenShift Playground link for quick access

4. openshift.1.3.projects.md
    - added OpenShift Playground link for quick access

5. openshift.1.5.status.md
    - added links to reference Info
    - added links to deploying application from images and source